### PR TITLE
Correct invalid naming ios files

### DIFF
--- a/src/ios/FirebasePerformancePlugin.h
+++ b/src/ios/FirebasePerformancePlugin.h
@@ -1,7 +1,7 @@
 #import <Cordova/CDV.h>
 
 @interface FirebasePerformancePlugin : CDVPlugin
-+ (FirebasePerformancePlugin *)FirebasePerformancePlugin;
++ (FirebasePerformancePlugin *)firebasePerformancePlugin;
 
 - (void)startTrace:(CDVInvokedUrlCommand *)command;
 - (void)incrementCounter:(CDVInvokedUrlCommand *)command;

--- a/src/ios/FirebasePerformancePlugin.m
+++ b/src/ios/FirebasePerformancePlugin.m
@@ -8,15 +8,15 @@
 @synthesize traces;
 
 static NSString*const LOG_TAG = @"FirebasePerformancePlugin[native]";
-static FirebasePerformancePlugin *FirebasePerformancePlugin;
+static FirebasePerformancePlugin *firebasePerformancePlugin;
 
-+ (FirebasePerformancePlugin *) FirebasePerformancePlugin {
-    return FirebasePerformancePlugin;
++ (FirebasePerformancePlugin *) firebasePerformancePlugin {
+    return firebasePerformancePlugin;
 }
 
 - (void)pluginInitialize {
     NSLog(@"Starting Firebase plugin");
-    FirebasePerformancePlugin = self;
+    firebasePerformancePlugin = self;
 }
 
 


### PR DESCRIPTION
### Goal

Separate identifier from class name.