### PR TITLE
Revert renaming of plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,12 +18,12 @@
 	<preference name="FIREBASE_PERFORMANCE_COLLECTION_ENABLED" default="true" />
 
 	<platform name="android">
-		<js-module name="FirebasePerformancePlugin" src="www/firebase.js">
-			<clobbers target="FirebasePerformancePlugin" />
+		<js-module name="FirebasePlugin" src="www/firebase.js">
+			<clobbers target="FirebasePlugin" />
 		</js-module>
 		<config-file parent="/*" target="res/xml/config.xml">
-			<feature name="FirebasePerformancePlugin">
-				<param name="android-package" value="org.apache.cordova.firebase.FirebasePerformancePlugin" />
+			<feature name="FirebasePlugin">
+				<param name="android-package" value="org.apache.cordova.firebase.FirebasePlugin" />
 				<param name="onload" value="true" />
 			</feature>
 		</config-file>
@@ -37,7 +37,7 @@
 			<meta-data android:name="firebase_performance_collection_enabled" android:value="$FIREBASE_PERFORMANCE_COLLECTION_ENABLED" />
 		</config-file>
 		<resource-file src="src/android/cordova-plugin-firebase-strings.xml" target="res/values/cordova-plugin-firebase-strings.xml" />
-		<source-file src="src/android/FirebasePerformancePlugin.java" target-dir="src/org/apache/cordova/firebase" />
+		<source-file src="src/android/FirebasePlugin.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/JavaScriptException.java" target-dir="src/org/apache/cordova/firebase"/>
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 		<preference name="ANDROID_ICON_ACCENT" default="#FF00FFFF" />
@@ -60,12 +60,12 @@
 	</platform>
 
 	<platform name="ios">
-		<js-module name="FirebasePerformancePlugin" src="www/firebase.js">
-			<clobbers target="FirebasePerformancePlugin" />
+		<js-module name="FirebasePlugin" src="www/firebase.js">
+			<clobbers target="FirebasePlugin" />
 		</js-module>
 		<config-file parent="/*" target="config.xml">
-			<feature name="FirebasePerformancePlugin">
-				<param name="ios-package" value="FirebasePerformancePlugin" />
+			<feature name="FirebasePlugin">
+				<param name="ios-package" value="FirebasePlugin" />
 				<param name="onload" value="true" />
 			</feature>
 		</config-file>
@@ -81,8 +81,8 @@
 			</array>
 		</config-file>
 
-		<header-file src="src/ios/FirebasePerformancePlugin.h" />
-		<source-file src="src/ios/FirebasePerformancePlugin.m" />
+		<header-file src="src/ios/FirebasePlugin.h" />
+		<source-file src="src/ios/FirebasePlugin.m" />
 
 		<podspec>
 			<config>

--- a/src/android/FirebasePerformancePlugin.java
+++ b/src/android/FirebasePerformancePlugin.java
@@ -43,13 +43,13 @@ import com.google.firebase.FirebaseTooManyRequestsException;
 import com.google.firebase.auth.PhoneAuthCredential;
 import com.google.firebase.auth.PhoneAuthProvider;
 
-public class FirebasePerformancePlugin extends CordovaPlugin {
+public class FirebasePlugin extends CordovaPlugin {
 
-    protected static FirebasePerformancePlugin instance = null;
+    protected static FirebasePlugin instance = null;
     private static CordovaInterface cordovaInterface = null;
     private static Context applicationContext = null;
     private static Activity cordovaActivity = null;
-    protected static final String TAG = "FirebasePerformancePlugin";
+    protected static final String TAG = "FirebasePlugin";
 
     private static boolean inBackground = true;
 
@@ -59,7 +59,7 @@ public class FirebasePerformancePlugin extends CordovaPlugin {
         cordovaActivity = this.cordova.getActivity();
         applicationContext = cordovaActivity.getApplicationContext();
         final Bundle extras = cordovaActivity.getIntent().getExtras();
-        FirebasePerformancePlugin.cordovaInterface = this.cordova;
+        FirebasePlugin.cordovaInterface = this.cordova;
         this.cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {
@@ -100,12 +100,12 @@ public class FirebasePerformancePlugin extends CordovaPlugin {
 
     @Override
     public void onPause(boolean multitasking) {
-        FirebasePerformancePlugin.inBackground = true;
+        FirebasePlugin.inBackground = true;
     }
 
     @Override
     public void onResume(boolean multitasking) {
-        FirebasePerformancePlugin.inBackground = false;
+        FirebasePlugin.inBackground = false;
     }
 
     @Override
@@ -168,7 +168,7 @@ public class FirebasePerformancePlugin extends CordovaPlugin {
     private HashMap<String, Trace> traces = new HashMap<String, Trace>();
 
     private void startTrace(final CallbackContext callbackContext, final String name) {
-        final FirebasePerformancePlugin self = this;
+        final FirebasePlugin self = this;
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {
@@ -194,7 +194,7 @@ public class FirebasePerformancePlugin extends CordovaPlugin {
     }
 
     private void incrementCounter(final CallbackContext callbackContext, final String name, final String counterNamed) {
-        final FirebasePerformancePlugin self = this;
+        final FirebasePlugin self = this;
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {
@@ -219,7 +219,7 @@ public class FirebasePerformancePlugin extends CordovaPlugin {
     }
 
     private void stopTrace(final CallbackContext callbackContext, final String name) {
-        final FirebasePerformancePlugin self = this;
+        final FirebasePlugin self = this;
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {

--- a/src/ios/FirebasePerformancePlugin.h
+++ b/src/ios/FirebasePerformancePlugin.h
@@ -1,7 +1,7 @@
 #import <Cordova/CDV.h>
 
-@interface FirebasePerformancePlugin : CDVPlugin
-+ (FirebasePerformancePlugin *)firebasePerformancePlugin;
+@interface FirebasePlugin : CDVPlugin
++ (FirebasePlugin *)firebasePlugin;
 
 - (void)startTrace:(CDVInvokedUrlCommand *)command;
 - (void)incrementCounter:(CDVInvokedUrlCommand *)command;

--- a/src/ios/FirebasePerformancePlugin.m
+++ b/src/ios/FirebasePerformancePlugin.m
@@ -1,22 +1,22 @@
-#import "FirebasePerformancePlugin.h"
+#import "FirebasePlugin.h"
 #import <Cordova/CDV.h>
 #import "Firebase.h"
 @import FirebasePerformance;
 
-@implementation FirebasePerformancePlugin
+@implementation FirebasePlugin
 
 @synthesize traces;
 
-static NSString*const LOG_TAG = @"FirebasePerformancePlugin[native]";
-static FirebasePerformancePlugin *firebasePerformancePlugin;
+static NSString*const LOG_TAG = @"FirebasePlugin[native]";
+static FirebasePlugin *firebasePlugin;
 
-+ (FirebasePerformancePlugin *) firebasePerformancePlugin {
-    return firebasePerformancePlugin;
++ (FirebasePlugin *) firebasePlugin {
+    return firebasePlugin;
 }
 
 - (void)pluginInitialize {
     NSLog(@"Starting Firebase plugin");
-    firebasePerformancePlugin = self;
+    firebasePlugin = self;
 }
 
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,7 +10,7 @@ interface IChannelOptions {
     visibility?: -1 | 0 | 1
 }
 
-interface FirebasePerformancePlugin {
+interface FirebasePlugin {
     getToken(success: (value: string) => void, error: (err: string) => void): void
     onTokenRefresh(success: (value: string) => void, error: (err: string) => void): void
     getAPNSToken(success: (value: string) => void, error: (err: string) => void): void
@@ -56,4 +56,4 @@ interface FirebasePerformancePlugin {
     incrementCounter(name: string, counterName: string, success: () => void, error: (err: string) => void): void
     stopTrace(name: string): void
 }
-declare var FirebasePerformancePlugin: FirebasePerformancePlugin; 
+declare var FirebasePlugin: FirebasePlugin; 

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -1,26 +1,22 @@
-var exec = require('cordova/exec');
+var exec = require("cordova/exec");
 
 exports.startTrace = function(name, success, error) {
-    exec(success, error, 'FirebasePerformancePlugin', 'startTrace', [name]);
+    exec(success, error, "FirebasePlugin", "startTrace", [name]);
 };
 
 exports.incrementCounter = function(name, counterNamed, success, error) {
-    exec(success, error, 'FirebasePerformancePlugin', 'incrementCounter', [
+    exec(success, error, "FirebasePlugin", "incrementCounter", [
         name,
         counterNamed
     ]);
 };
 
 exports.stopTrace = function(name, success, error) {
-    exec(success, error, 'FirebasePerformancePlugin', 'stopTrace', [name]);
+    exec(success, error, "FirebasePlugin", "stopTrace", [name]);
 };
 
 exports.setPerformanceCollectionEnabled = function(enabled, success, error) {
-    exec(
-        success,
-        error,
-        'FirebasePerformancePlugin',
-        'setPerformanceCollectionEnabled',
-        [enabled]
-    );
+    exec(success, error, "FirebasePlugin", "setPerformanceCollectionEnabled", [
+        enabled
+    ]);
 };


### PR DESCRIPTION
### Goal

I initially renamed the plugin from `FirebasePlugin` to `FirebasePerformancePlugin` because we only used it for performance monitoring but what I didn't put into account is that the ionic native interface for the plugin will still be expecting `FirebasePlugin` and not `FirebasePerformancePlugin` so I have to revert the changes.